### PR TITLE
fix: disable config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,10 @@ import register from '@babel/register';
 
 register({
   extensions: ['.js', '.ts', '.tsx', '.mjs'],
+  // these disable any babel config files in the project so we can run our
+  // very specific babel config for the CLI
   babelrc: false,
+  configFile: false,
   presets: [
     ['@babel/preset-env', { targets: { node: true } }],
     '@babel/preset-typescript',


### PR DESCRIPTION
Adds `configFile: false` to the `@babel/register` setup in the CLI for mono repos with a babel config.