### PR TITLE
fix: change to export type to comply with isolatedModules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "",
   "repository": {

--- a/src/generate-types.test.ts
+++ b/src/generate-types.test.ts
@@ -72,7 +72,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -216,7 +216,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -277,7 +277,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -362,7 +362,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -473,7 +473,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -598,7 +598,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -720,7 +720,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -798,7 +798,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -882,7 +882,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -988,7 +988,7 @@ describe('generate-types', () => {
         SanityDocument,
       } from \\"sanity-codegen\\";
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -322,7 +322,7 @@ async function generateTypes({
         SanityDocument,
       } from 'sanity-codegen';
 
-      export {
+      export type {
         SanityReference,
         SanityAsset,
         SanityImage,


### PR DESCRIPTION
The exported type break if isolated modules is enabled in the tsconfig. This fixes the re-exported types by adding `export type`