### PR TITLE
fix: include regenerator-runtime for UMD bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sanity Codegen ✨ · [![codecov](https://codecov.io/gh/ricokahler/sanity-codegen/branch/main/graph/badge.svg?token=tsUGZsR5QG)](https://codecov.io/gh/ricokahler/sanity-codegen) [![github status checks](https://badgen.net/github/checks/ricokahler/sanity-codegen/main)](https://github.com/ricokahler/sanity-codegen/actions)
+# Sanity Codegen ✨ · [![codecov](https://codecov.io/gh/ricokahler/sanity-codegen/branch/main/graph/badge.svg?token=tsUGZsR5QG)](https://codecov.io/gh/ricokahler/sanity-codegen) [![github status checks](https://badgen.net/github/checks/ricokahler/sanity-codegen/main)](https://github.com/ricokahler/sanity-codegen/actions) [![bundlephobia](https://badgen.net/bundlephobia/minzip/sanity-codegen)](https://bundlephobia.com/result?p=sanity-codegen)
 
 > Generate TypeScript types from your Sanity schemas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7727,8 +7727,7 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
-      "dev": true
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regenerator-transform": {
       "version": "0.14.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "",
   "repository": {
@@ -24,7 +24,8 @@
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/register": "^7.12.1",
     "@types/prettier": "^2.1.5",
-    "babel-plugin-module-resolver": "^4.0.0"
+    "babel-plugin-module-resolver": "^4.0.0",
+    "regenerator-runtime": "^0.13.7"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,10 @@ export default [
       resolve({ extensions, modulesOnly: true }),
       babel({
         babelrc: false,
-        presets: ['@babel/preset-typescript'],
+        presets: [
+          ['@babel/preset-env', { targets: 'node 10 and not IE 11' }],
+          '@babel/preset-typescript',
+        ],
         plugins: ['@babel/plugin-transform-runtime'],
         babelHelpers: 'runtime',
         extensions,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default [
     external: [/^@babel\/runtime/],
   },
   {
-    input: './src/index.ts',
+    input: './src/index.umd.ts',
     output: {
       file: './dist/index.js',
       format: 'umd',
@@ -40,5 +40,6 @@ export default [
         extensions,
       }),
     ],
+    external: ['regenerator-runtime/runtime'],
   },
 ];

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -16,11 +16,13 @@ async function build() {
 
   console.log('Compiling types…');
   await exec('npx tsc');
+  await exec('rm ./dist/index.umd.d.ts');
 
   console.log('Compiling Non-Client JS…');
   await exec(
     'npx babel -x .ts,.js --ignore /**/*.test.ts,/**/*.d.ts ./src --out-dir ./dist'
   );
+  await exec('rm ./dist/index.umd.js');
 
   console.log('Compiling Client JS…');
   await exec('npx rollup -c');

--- a/src/index.umd.ts
+++ b/src/index.umd.ts
@@ -1,0 +1,4 @@
+// entry point for the umd bundle that includes the regenerator-runtime
+import 'regenerator-runtime/runtime';
+export * from './types';
+export * from './client';


### PR DESCRIPTION
Just tried running this build in next.js and found that the UMD bundles fails (used by SSR) because the regenerator-runtime was not found in the code.