### PR TITLE
fix: improve no-op with expando proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "",
   "repository": {

--- a/src/no-op.ts
+++ b/src/no-op.ts
@@ -1,2 +1,12 @@
-// Used to resolve the sanity part system to a no-op
-export default () => {};
+// Used to resolve the sanity part system to a no-op.
+// This ES6 proxy intercepts all properties calls and returns itself
+const proxy: any = new Proxy(
+  function () {
+    return proxy;
+  },
+  {
+    get: () => proxy,
+  }
+);
+
+module.exports = proxy;

--- a/src/schema-creator-shim.ts
+++ b/src/schema-creator-shim.ts
@@ -1,6 +1,6 @@
 // The purpose of this file is to shim out the `createSchema` call from
 // `import createSchema from 'part:@sanity/base/schema-creator';`
-// so that it simple re-exports the uncompiled type
+// so that it simply re-exports the uncompiled type
 function createSchemaShim({ types }: any) {
   return types;
 }


### PR DESCRIPTION
I ran into a bug when running codegen. If you import `withDocument` like so

```ts
import { withDocument } from 'part:@sanity/form-builder';
```

it breaks because the no-op package only resolves to one function. This fix greatly improves the no-op by creating this forever recursive object that you can forever invoke without it ever throwing… it's kind of fun.

Paste this into your console for a whirl

```js
const proxy = new Proxy(
  function () {
    return proxy;
  },
  {
    get: () => proxy,
  }
);

proxy.fjeiw().oaf.fewafew.affdj().sfejs.fj.ghr.vhrvreh.hr.e.feiwojio()()()()()() // doesn't throw!
```