### PR TITLE
fix: `import type` too

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "description": "",
   "repository": {

--- a/src/generate-types.test.ts
+++ b/src/generate-types.test.ts
@@ -61,7 +61,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -205,7 +205,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -266,7 +266,7 @@ describe('generate-types', () => {
 
     expect(result.includes('name?: string')).toBe(true);
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -351,7 +351,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -462,7 +462,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo, bar] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -587,7 +587,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo, bar, baz] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -709,7 +709,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -787,7 +787,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -871,7 +871,7 @@ describe('generate-types', () => {
     const result = await generateTypes({ types: [foo, bar, baz] });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,
@@ -977,7 +977,7 @@ describe('generate-types', () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
-      "import {
+      "import type {
         SanityReference,
         SanityAsset,
         SanityImage,

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -311,7 +311,7 @@ async function generateTypes({
 
   const typeStrings = [
     `
-      import {
+      import type {
         SanityReference,
         SanityAsset,
         SanityImage,


### PR DESCRIPTION
I included a change back in #10 to do `export type`. During that time I should've also made it do `import type` too.