### PR TITLE
fix: _createAt typo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "",
   "repository": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,7 +60,7 @@ export interface SanityBlock {
 
 export interface SanityDocument {
   _id: string;
-  _createAt: string;
+  _createdAt: string;
   _rev: string;
   _updatedAt: string;
 }


### PR DESCRIPTION
There's a typo in the types.

I meant `_createdAt` but instead I had `_createAt`