### PR TITLE
feat: client cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.3.1",
+  "version": "0.4.0-alpha.3",
   "private": true,
   "description": "",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.4.0-alpha.3",
+  "version": "0.4.0-alpha.4",
   "private": true,
   "description": "",
   "repository": {

--- a/src/client/create-client.test.ts
+++ b/src/client/create-client.test.ts
@@ -140,6 +140,82 @@ describe('get', () => {
       ]
     `);
   });
+
+  it('caches the result between create client calls', async () => {
+    const mockDoc = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'settings',
+      _rev: 'XoaOTvah7ZFSBIsJK8Ahfx',
+      _type: 'settings',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+
+    const mockFetch: any = jest.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ result: [mockDoc] }),
+    }));
+
+    const sanity = createClient({
+      projectId: 'test-project-id',
+      dataset: 'test-dataset',
+      fetch: mockFetch,
+    });
+
+    const once = await sanity.get('settings', 'settings');
+    const twice = await sanity.get('settings', 'settings');
+
+    expect(once).toBe(mockDoc);
+    expect(twice).toBe(mockDoc);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_id+%3D%3D+%22settings%22+%5D",
+        Object {
+          "headers": Object {
+            "Accept": "application/json",
+          },
+        },
+      ]
+    `);
+  });
+
+  it('allows the cache calls to be disabled', async () => {
+    const mockDoc = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'settings',
+      _rev: 'XoaOTvah7ZFSBIsJK8Ahfx',
+      _type: 'settings',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+
+    const mockFetch: any = jest.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ result: [mockDoc] }),
+    }));
+
+    const sanity = createClient({
+      projectId: 'test-project-id',
+      dataset: 'test-dataset',
+      fetch: mockFetch,
+      disabledCache: true,
+    });
+
+    await sanity.get('settings', 'settings');
+    await sanity.get('settings', 'settings');
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_id+%3D%3D+%22settings%22+%5D",
+        Object {
+          "headers": Object {
+            "Accept": "application/json",
+          },
+        },
+      ]
+    `);
+  });
 });
 
 describe('getAll', () => {
@@ -180,15 +256,149 @@ describe('getAll', () => {
 
     expect(docs).toEqual([postOne, postTwo]);
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
       Array [
-        "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22%5D",
-        Object {
-          "headers": Object {
-            "Accept": "application/json",
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22%5D+%7B+_id+%7D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
           },
-        },
+        ],
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_id+in+%5B%27post-one%27%2C+%27post-two%27%5D%5D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
+          },
+        ],
+      ]
+    `);
+  });
+
+  it('does not re-fetch cached values', async () => {
+    const postOne = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'post-one',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+    const postTwo = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'post-two',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+    const postTwoDraft = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'drafts.post-two',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+
+    const mockFetch: any = jest.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ result: [postOne, postTwo, postTwoDraft] }),
+    }));
+
+    const sanity = createClient({
+      projectId: 'test-project-id',
+      dataset: 'test-dataset',
+      fetch: mockFetch,
+    });
+
+    await sanity.get('post', 'post-one');
+
+    const docs = await sanity.getAll('post');
+
+    expect(docs).toEqual([postOne, postTwo]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_id+%3D%3D+%22post-one%22+%5D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
+          },
+        ],
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22%5D+%7B+_id+%7D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
+          },
+        ],
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_id+in+%5B%27post-two%27%5D%5D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
+          },
+        ],
+      ]
+    `);
+  });
+
+  it('only makes one network call when the cache is disabled', async () => {
+    const postOne = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'post-one',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+    const postTwo = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'post-two',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+    const postTwoDraft = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'drafts.post-two',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+
+    const mockFetch: any = jest.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ result: [postOne, postTwo, postTwoDraft] }),
+    }));
+
+    const sanity = createClient({
+      projectId: 'test-project-id',
+      dataset: 'test-dataset',
+      fetch: mockFetch,
+      disabledCache: true,
+    });
+    const docs = await sanity.getAll('post');
+
+    expect(docs).toEqual([postOne, postTwo]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22%5D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
+          },
+        ],
       ]
     `);
   });
@@ -223,15 +433,25 @@ describe('getAll', () => {
 
     expect(docs).toEqual([postOne, postTwo]);
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
       Array [
-        "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22+%26%26+name+%3D%3D+%22test%22%5D",
-        Object {
-          "headers": Object {
-            "Accept": "application/json",
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22+%26%26+name+%3D%3D+%22test%22%5D+%7B+_id+%7D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
           },
-        },
+        ],
+        Array [
+          "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_id+in+%5B%27post-one%27%2C+%27post-two%27%5D%5D",
+          Object {
+            "headers": Object {
+              "Accept": "application/json",
+            },
+          },
+        ],
       ]
     `);
   });
@@ -276,10 +496,10 @@ describe('getAll', () => {
 
     expect(docs).toEqual([postOne, postTwoDraft]);
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
     expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
-        "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22%5D",
+        "https://test-project-id.api.sanity.io/v1/data/query/test-dataset?query=*+%5B_type+%3D%3D+%22post%22%5D+%7B+_id+%7D",
         Object {
           "headers": Object {
             "Accept": "application/json",
@@ -333,5 +553,37 @@ describe('expand', () => {
         },
       ]
     `);
+  });
+});
+
+describe('clearCache', () => {
+  it('clears the caches', async () => {
+    const mockDoc = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'settings',
+      _rev: 'XoaOTvah7ZFSBIsJK8Ahfx',
+      _type: 'settings',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+
+    const mockFetch: any = jest.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ result: [mockDoc] }),
+    }));
+
+    const sanity = createClient({
+      projectId: 'test-project-id',
+      dataset: 'test-dataset',
+      fetch: mockFetch,
+    });
+
+    const once = await sanity.get('settings', 'settings');
+    sanity.clearCache();
+    const twice = await sanity.get('settings', 'settings');
+
+    expect(once).toBe(mockDoc);
+    expect(twice).toBe(mockDoc);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/client/create-client.ts
+++ b/src/client/create-client.ts
@@ -82,7 +82,7 @@ function createClient<Documents extends { _type: string; _id: string }>({
     type R = { _type: T } & Documents;
 
     if (disabledCache) {
-      return await query<{ _id: string }>(
+      return await query<R>(
         `* [_type == "${type}"${filterClause ? ` && ${filterClause}` : ''}]`
       );
     }


### PR DESCRIPTION
This PR adds a simple caching mechanism to the client.

The client is nice a simple but I've learned it can quickly eat quotas when in heavy development 😅. This cache should remove a dimension and speed up builds as well.

---

This has been published to `sanity-codegen@next` if you wanted to try it before it's released