### PR TITLE
feat: babel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,17 @@ import { SanityCodegenConfig } from 'sanity-codegen';
 const config: SanityCodegenConfig = {
   schemaPath: './path/to/your/schema',
   outputPath: './schema.ts',
+  // NOTE: The CLI ships with a pre-configured babel config that shims out
+  // the Sanity parts system. This babel config does not read from any
+  // `.babelrc` or `babel.config.js`. You can only configure extra babel
+  // options here.
+  // babelOptions: require('./.babelrc.json'),
 };
 
 export default config;
 ```
 
-[See here for the rest of the available options.](https://github.com/ricokahler/sanity-codegen/blob/13250d60892bfc95b73d88b28e88b574a31935a7/src/generate-types.ts#L85-L109)
+[See here for the rest of the available options.](https://github.com/ricokahler/sanity-codegen/blob/d4eb4a8ac5f6d27f709697ccdbd2a296d1e51dc2/src/generate-types.ts#L97-L121)
 
 Then run the CLI with [`npx`](https://github.com/npm/npx) at the root of your sanity project.
 
@@ -211,4 +216,4 @@ generateTypes({
 });
 ```
 
-However you may run into challenges with executing the code if your schema imports from the sanity parts system. [The CLI tries to help you with this.](https://github.com/ricokahler/sanity-codegen/blob/13250d60892bfc95b73d88b28e88b574a31935a7/src/cli.ts#L18-L34)
+However you may run into challenges with executing the code if your schema imports from the sanity parts system. [The CLI tries to help you with this.](https://github.com/ricokahler/sanity-codegen/blob/d4eb4a8ac5f6d27f709697ccdbd2a296d1e51dc2/src/cli.ts#L8-L40)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ import { SanityCodegenConfig } from 'sanity-codegen';
 const config: SanityCodegenConfig = {
   schemaPath: './path/to/your/schema',
   outputPath: './schema.ts',
+
   // NOTE: The CLI ships with a pre-configured babel config that shims out
   // the Sanity parts system. This babel config does not read from any
   // `.babelrc` or `babel.config.js`. You can only configure extra babel
   // options here.
-  // babelOptions: require('./.babelrc.json'),
+  // babelOptions: require('./.babelrc.json'), // (optional)
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "",
   "repository": {

--- a/src/augments.d.ts
+++ b/src/augments.d.ts
@@ -5,5 +5,8 @@ declare module '@babel/register' {
   const register: (
     options: TransformOptions & { extensions: string[] }
   ) => void;
+
+  export const revert: () => void;
+
   export default register;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,10 @@ export interface SanityCodegenConfig
    * The output path for the resulting codegen. Defaults to `./schema.ts`
    */
   outputPath?: string;
+  /**
+   * Pass options directly to `@babel/register`
+   */
+  babelOptions?: any;
 }
 
 /**


### PR DESCRIPTION
This enables extra babel options to be passed to the CLI prior to running code gen.

My use case for this was working with a monorepo. By default babel doesn't compile anything in `node_modules` including symlinked packages that yarn workspaces creates.