### PR TITLE
fix: sanity client build in sanity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "",
   "repository": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,11 +15,18 @@ export default [
       resolve({ extensions, modulesOnly: true }),
       babel({
         babelrc: false,
+        configFile: false,
         presets: [
           ['@babel/preset-env', { targets: 'node 10 and not IE 11' }],
           '@babel/preset-typescript',
         ],
-        plugins: ['@babel/plugin-transform-runtime'],
+        plugins: [
+          '@babel/plugin-transform-runtime',
+          [
+            '@babel/plugin-proposal-object-rest-spread',
+            { loose: true, useBuiltIns: true },
+          ],
+        ],
         babelHelpers: 'runtime',
         extensions,
       }),
@@ -38,6 +45,7 @@ export default [
       resolve({ extensions, modulesOnly: true }),
       babel({
         babelrc: false,
+        configFile: false,
         presets: ['@babel/preset-env', '@babel/preset-typescript'],
         babelHelpers: 'bundled',
         extensions,


### PR DESCRIPTION
I tried using sanity codegen's client inside sanity studio and… it won't compile!

I think this is because Sanity's using a webpack version that's over 3 years old (v3.8.1). The sanity babel config ignores node_modules by default however it's common practice for the ESM modules (`.esm.js`) to use newer javascript but the object spread operator is apparently too new for webpack 3.