### PR TITLE
fix: change preset env targets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-env", { "targets": { "node": true } }],
+    ["@babel/preset-env", { "targets": "maintained node versions" }],
     "@babel/preset-typescript"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": true,
   "description": "",
   "repository": {


### PR DESCRIPTION
I think babel or browerslist recently updated something where `targets: { node: true }` no-longer compiles optional chaining down.

This results in a smaller node build but also breaks vercel deploys (because they still use the last LTS, node 12).

Anyway, this fixes that.