### PR TITLE
feat: cdn client

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ export default createClient<Documents>({
   token: '...',
   // by default sanity-codegen caches responses in memory. this can be disabled if desired
   // disabledCache: true,
+  //
+  // (optional) enables the usage of `apicdn.sanity.io`. this is recommended
+  // if you plan on using this in browsers. don't use this with preview mode
+  // see here: https://www.sanity.io/docs/api-cdn
+  // useCdn: true,
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "private": true,
   "description": "",
   "repository": {

--- a/src/client/create-client.test.ts
+++ b/src/client/create-client.test.ts
@@ -54,6 +54,60 @@ describe('query', () => {
       ]
     `);
   });
+
+  it('conditionally applies tokens and CDN endpoints', async () => {
+    const postOne = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'post-one',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+    const postTwo = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'post-two',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+    const postTwoDraft = {
+      _createdAt: '2020-10-24T03:00:29Z',
+      _id: 'drafts.post-two',
+      _rev: 'rev',
+      _type: 'post',
+      _updatedAt: '2020-10-24T03:04:54Z',
+    };
+
+    const mockFetch: any = jest.fn(() => ({
+      ok: true,
+      json: () => Promise.resolve({ result: [postOne, postTwo, postTwoDraft] }),
+    }));
+
+    const sanity = createClient({
+      projectId: 'test-project-id',
+      dataset: 'test-dataset',
+      fetch: mockFetch,
+      previewMode: false,
+      token: 'test-token',
+      useCdn: true,
+    });
+
+    const docs = await sanity.query('*');
+
+    expect(docs).toEqual([postOne, postTwo]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        "https://test-project-id.apicdn.sanity.io/v1/data/query/test-dataset?query=*",
+        Object {
+          "headers": Object {
+            "Accept": "application/json",
+          },
+        },
+      ]
+    `);
+  });
 });
 
 describe('get', () => {

--- a/src/client/create-client.ts
+++ b/src/client/create-client.ts
@@ -7,6 +7,7 @@ interface CreateClientOptions {
   token?: string;
   previewMode?: boolean;
   disabledCache?: boolean;
+  useCdn?: boolean;
 }
 
 interface SanityResult<T> {
@@ -22,6 +23,7 @@ function createClient<Documents extends { _type: string; _id: string }>({
   previewMode = false,
   fetch,
   disabledCache,
+  useCdn,
 }: CreateClientOptions) {
   const cache: { [key: string]: any } = {};
 
@@ -129,10 +131,12 @@ function createClient<Documents extends { _type: string; _id: string }>({
 
     searchParams.set('query', query);
     const response = await jsonFetch<SanityResult<T>>(
-      `https://${projectId}.api.sanity.io/v1/data/query/${dataset}?${searchParams.toString()}`,
+      `https://${projectId}.${
+        useCdn ? 'apicdn' : 'api'
+      }.sanity.io/v1/data/query/${dataset}?${searchParams.toString()}`,
       {
         // conditionally add the authorization header if the token is present
-        ...(token && { headers: { Authorization: `Bearer ${token}` } }),
+        ...(preview && { headers: { Authorization: `Bearer ${token}` } }),
       }
     );
 


### PR DESCRIPTION
Allows the client to use `apicdn.sanity.io`. Adds a `useCdn` flag