### PR TITLE
feat: mutable preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ function query<T = any>(query: string): Promise<T[]>;
  * the client
  */
 function clearCache(): void;
+
+/**
+ * Flip whether or not this client is using preview mode or not. Useful for
+ * preview mode within next.js.
+ */
+function setPreviewMode(previewMode: boolean): void;
 ```
 
 The design behind the client is to fetch full documents and handle projections and transforms in code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "description": "",
   "repository": {


### PR DESCRIPTION
This adds the method `.setPreviewMode()` to the client allowing for preview mode to be set after the object's creation.

This is useful for next.js preview mode.
