### PR TITLE
fix(client): fix incorrect token condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "",
   "repository": {

--- a/src/client/create-client.ts
+++ b/src/client/create-client.ts
@@ -108,7 +108,8 @@ function createClient<Documents extends { _type: string; _id: string }>({
       }.sanity.io/v1/data/query/${dataset}?${searchParams.toString()}`,
       {
         // conditionally add the authorization header if the token is present
-        ...(preview && { headers: { Authorization: `Bearer ${token}` } }),
+        ...(token &&
+          !useCdn && { headers: { Authorization: `Bearer ${token}` } }),
       }
     );
 


### PR DESCRIPTION
Fixes a bug where the token is not sent unless preview mode is active. Now the token will be sent regardless of preview mode.