### PR TITLE
fix(client): remove `v` prefix for `apiVersion`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "sanity-codegen",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-proposal-class-properties": "7.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sanity-codegen",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "description": "",
   "repository": {

--- a/src/client/create-client.ts
+++ b/src/client/create-client.ts
@@ -21,7 +21,7 @@ function createClient<Documents extends { _type: string; _id: string }>({
   projectId,
   token,
   previewMode: _previewMode = false,
-  apiVersion = 'v1',
+  apiVersion = '1',
   fetch,
   useCdn,
 }: CreateClientOptions) {
@@ -107,7 +107,7 @@ function createClient<Documents extends { _type: string; _id: string }>({
     const response = await jsonFetch<SanityResult<T>>(
       `https://${projectId}.${
         useCdn ? 'apicdn' : 'api'
-      }.sanity.io/${apiVersion}/data/query/${dataset}?${searchParams.toString()}`,
+      }.sanity.io/v${apiVersion}/data/query/${dataset}?${searchParams.toString()}`,
       {
         // conditionally add the authorization header if the token is present
         ...(token &&


### PR DESCRIPTION
The `v` prefix isn't actually required by the official client so we'll change that here to match