### PR TITLE
fix(groq-codegen): fix incorrect types + new test fixtures

### DIFF
--- a/packages/groq-codegen/fixtures/assert-groq-type-output.test.ts
+++ b/packages/groq-codegen/fixtures/assert-groq-type-output.test.ts
@@ -1,0 +1,71 @@
+import { assertGroqTypeOutput } from './assert-groq-type-output';
+
+describe('assertGroqTypeOutput', () => {
+  it('should work with the correct types', async () => {
+    const types = await assertGroqTypeOutput({
+      schema: [
+        {
+          name: 'fooObj',
+          type: 'document',
+          fields: [
+            {
+              name: 'foo',
+              type: 'string',
+            },
+          ],
+        },
+      ],
+      query: `*[_type == 'fooObj'].foo`,
+      expectedType: `Array<string | undefined>`,
+    });
+
+    expect(types).toMatchInlineSnapshot(`
+      "type Query = Sanity.SafeIndexedAccess<
+        Extract<
+          Sanity.Schema.Document[][number],
+          {
+            _type: 'fooObj';
+          }
+        >[][number],
+        'foo'
+      >[];"
+    `);
+  });
+
+  it('should throw with incorrect types', async () => {
+    let caught = false;
+
+    try {
+      await assertGroqTypeOutput({
+        schema: [
+          {
+            name: 'fooObj',
+            type: 'document',
+            fields: [
+              {
+                name: 'foo',
+                type: 'string',
+              },
+            ],
+          },
+        ],
+        query: `*[_type == 'fooObj'].foo`,
+        expectedType: `number[]`,
+      });
+    } catch (e) {
+      caught = true;
+      expect(e).toMatchInlineSnapshot(`
+        [Error: GROQ assertion failed.
+
+        Argument of type 'ExpectedType' is not assignable to parameter of type 'QueryType'.
+        Type 'number' is not assignable to type 'string | undefined'.
+
+        Argument of type 'QueryType' is not assignable to parameter of type 'ExpectedType'.
+        Type 'string | undefined' is not assignable to type 'number'.
+        Type 'undefined' is not assignable to type 'number'.]
+      `);
+    }
+
+    expect(caught).toBe(true);
+  });
+});

--- a/packages/groq-codegen/fixtures/assert-groq-type-output.test.ts
+++ b/packages/groq-codegen/fixtures/assert-groq-type-output.test.ts
@@ -16,7 +16,7 @@ describe('assertGroqTypeOutput', () => {
         },
       ],
       query: `*[_type == 'fooObj'].foo`,
-      expectedType: `Array<string | undefined>`,
+      expectedType: `Array<string | null>`,
     });
 
     expect(types).toMatchInlineSnapshot(`
@@ -58,11 +58,11 @@ describe('assertGroqTypeOutput', () => {
         [Error: GROQ assertion failed.
 
         Argument of type 'ExpectedType' is not assignable to parameter of type 'QueryType'.
-        Type 'number' is not assignable to type 'string | undefined'.
+        Type 'number' is not assignable to type 'string | null'.
 
         Argument of type 'QueryType' is not assignable to parameter of type 'ExpectedType'.
-        Type 'string | undefined' is not assignable to type 'number'.
-        Type 'undefined' is not assignable to type 'number'.]
+        Type 'string | null' is not assignable to type 'number'.
+        Type 'null' is not assignable to type 'number'.]
       `);
     }
 

--- a/packages/groq-codegen/fixtures/assert-groq-type-output.ts
+++ b/packages/groq-codegen/fixtures/assert-groq-type-output.ts
@@ -12,12 +12,14 @@ interface Params {
   query: string;
   schema: any[];
   expectedType: string;
+  debug?: boolean;
 }
 
 export async function assertGroqTypeOutput({
   schema,
   query,
   expectedType,
+  debug,
 }: Params) {
   const compilerOptions: ts.CompilerOptions = {
     strict: true,
@@ -77,8 +79,21 @@ export async function assertGroqTypeOutput({
 
   const emitResult = program.emit();
 
+  if (debug) {
+    console.log(
+      prettier.format(
+        `
+          ${schemaCode}
+
+          ${queryCode}
+        `,
+        { parser: 'typescript', singleQuote: true },
+      ),
+    );
+  }
+
   if (emitResult.emitSkipped) {
-    throw new Error('emit skipped');
+    throw new Error('Emit skipped');
   }
 
   const diagnostics = [

--- a/packages/groq-codegen/fixtures/assert-groq-type-output.ts
+++ b/packages/groq-codegen/fixtures/assert-groq-type-output.ts
@@ -1,0 +1,113 @@
+import generate from '@babel/generator';
+import prettier from 'prettier';
+import {
+  schemaNormalizer,
+  generateSchemaTypes,
+} from '@sanity-codegen/schema-codegen';
+import ts from 'typescript';
+import { transformGroqToTypescript } from '../src/transform-groq-to-typescript';
+import { stripIndent, stripIndents } from 'common-tags';
+
+interface Params {
+  query: string;
+  schema: any[];
+  expectedType: string;
+}
+
+export async function assertGroqTypeOutput({
+  schema,
+  query,
+  expectedType,
+}: Params) {
+  const compilerOptions: ts.CompilerOptions = {
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+    outDir: './dist',
+    esModuleInterop: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    noEmit: true,
+  };
+
+  // seems like the types to babel are mismatched
+  // @ts-expect-error
+  const { code: groqCodegen } = generate(transformGroqToTypescript({ query }));
+  const schemaCode = await generateSchemaTypes({
+    schema: schemaNormalizer(schema),
+  });
+  const queryCode = stripIndent`
+    declare namespace Sanity {
+      namespace Queries {
+        type QueryType = ${stripIndent(groqCodegen)};
+      }
+    }
+  `;
+
+  const testEntryCode = stripIndent`
+    /** used to dismiss any unused errors */
+    declare function sideEffect(x: any): void;
+
+    type ExpectedType = ${stripIndent(expectedType)};
+    declare const valueA: Sanity.Queries.QueryType;
+    declare const valueB: ExpectedType;
+    
+    const fnA = <T extends Sanity.Queries.QueryType>(t: T) => sideEffect(t);
+    const fnB = <T extends ExpectedType>(t: T) => sideEffect(t);
+
+    // use the above function with bounded polymorphism to assert that the
+    // ExpectedType conforms to the outputted QueryType and vice versa
+    fnA(valueB);
+    fnB(valueA);
+  `;
+
+  const host = ts.createCompilerHost(compilerOptions);
+  const originalReadFile = host.readFile.bind(host);
+  host.readFile = (fileName) => {
+    if (fileName === 'query.d.ts') return queryCode;
+    if (fileName === 'schema.d.ts') return schemaCode;
+    if (fileName === 'test-entry.ts') return testEntryCode;
+    return originalReadFile(fileName);
+  };
+
+  const program = ts.createProgram(
+    ['query.d.ts', 'schema.d.ts', 'test-entry.ts'],
+    compilerOptions,
+    host,
+  );
+
+  const emitResult = program.emit();
+
+  if (emitResult.emitSkipped) {
+    throw new Error('emit skipped');
+  }
+
+  const diagnostics = [
+    ...program.getGlobalDiagnostics(),
+    ...program.getOptionsDiagnostics(),
+    ...program.getSemanticDiagnostics(),
+    ...program.getSyntacticDiagnostics(),
+    ...program.getDeclarationDiagnostics(),
+    ...program.getConfigFileParsingDiagnostics(),
+  ];
+
+  if (diagnostics.length) {
+    throw new Error(stripIndents`
+      GROQ assertion failed.
+
+      ${diagnostics
+        .map((diagnostic) =>
+          stripIndents(
+            ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+          ),
+        )
+        .join('\n\n')}
+    `);
+  }
+
+  return stripIndent`
+    ${prettier.format(`type Query = ${groqCodegen}`, {
+      parser: 'typescript',
+      singleQuote: true,
+    })}
+  `;
+}

--- a/packages/groq-codegen/src/generate-groq-types.test.ts
+++ b/packages/groq-codegen/src/generate-groq-types.test.ts
@@ -14,12 +14,14 @@ describe('generateGroqTypes', () => {
       declare namespace Sanity {
         namespace Queries {
           type BookAuthor = Sanity.SafeIndexedAccess<
-            Extract<
-              Sanity.Schema.Document[][number],
-              {
-                _type: \\"book\\";
-              }
-            >[][number],
+            Sanity.ArrayElementAccess<
+              Extract<
+                Sanity.Schema.Document[][number],
+                {
+                  _type: \\"book\\";
+                }
+              >[]
+            >,
             \\"author\\"
           >;
           type BookTitles = Sanity.SafeIndexedAccess<

--- a/packages/types/ambient.d.ts
+++ b/packages/types/ambient.d.ts
@@ -74,8 +74,17 @@ declare namespace Sanity {
 
   type Keyed<T> = T extends object ? T & { _key: string } : T;
 
+  // TODO: possibly move these into a Codegen namespace into the codegen package
+  type UndefinedToNull<T> = T extends null | undefined
+    ? NonNullable<T> | null
+    : NonNullable<T>;
+
   type SafeIndexedAccess<
-    T extends { [key: string]: any } | undefined,
+    T extends { [key: string]: any } | null | undefined,
     K extends keyof NonNullable<T>
-  > = T extends undefined ? NonNullable<T>[K] | undefined : NonNullable<T>[K];
+  > = T extends null | undefined
+    ? UndefinedToNull<NonNullable<T>[K]> | null
+    : UndefinedToNull<NonNullable<T>[K]>;
+
+  type ArrayElementAccess<T extends any[]> = T[number] | null;
 }


### PR DESCRIPTION
This PR:

- adds new test fixtures to allow us to write the expected type and have the typescript compiler throw if those types don't match
- fixes a few errors regarding undefines and nulls with attribute access