### PR TITLE
fix(groq-codegen): fix bug with references not showing up

### DIFF
--- a/packages/groq-codegen/src/__example-files__/example-file.ts
+++ b/packages/groq-codegen/src/__example-files__/example-file.ts
@@ -21,6 +21,8 @@ export const getStaticProps = async () => {
     `,
   );
 
+  sanity.query('AllBooks', groq`*[_type == 'book']`);
+
   return { props: { author } };
 };
 

--- a/packages/groq-codegen/src/__example-files__/example-schema.ts
+++ b/packages/groq-codegen/src/__example-files__/example-schema.ts
@@ -9,6 +9,12 @@ export const exampleSchema = [
         type: 'object',
         fields: [{ name: 'name', type: 'string' }],
       },
+      { name: 'description', type: 'blocks' },
     ],
+  },
+  {
+    name: 'blocks',
+    type: 'array',
+    of: [{ type: 'block' }],
   },
 ];

--- a/packages/groq-codegen/src/generate-groq-types.test.ts
+++ b/packages/groq-codegen/src/generate-groq-types.test.ts
@@ -16,10 +16,32 @@ describe('generateGroqTypes', () => {
 
       declare namespace Sanity {
         namespace Queries {
+          type AllBooks = {
+            _type: \\"book\\";
+            _id: string;
+            title?: string;
+            author?: {
+              name?: string;
+            };
+            description?: Ref_44wbp4;
+          }[];
           type BookAuthor = {
             name?: string;
           } | null;
           type BookTitles = (string | null)[];
+
+          type Ref_44wbp4 = {
+            _key: string;
+            _type: \\"block\\";
+            children: {
+              _key: string;
+              _type: \\"span\\";
+              marks?: unknown[];
+              text?: string;
+            }[];
+            markDefs?: unknown[];
+            style?: string;
+          }[];
 
           /**
            * A keyed type of all the codegen'ed queries. This type is used for
@@ -28,6 +50,7 @@ describe('generateGroqTypes', () => {
           type QueryMap = {
             BookAuthor: BookAuthor;
             BookTitles: BookTitles;
+            AllBooks: AllBooks;
           };
         }
       }

--- a/packages/groq-codegen/src/generate-groq-types.ts
+++ b/packages/groq-codegen/src/generate-groq-types.ts
@@ -62,7 +62,7 @@ export async function generateGroqTypes({
         acc.queries[queryKey] = query;
 
         for (const [key, value] of Object.entries(references)) {
-          acc[key] = value;
+          acc.references[key] = value;
         }
 
         return acc;

--- a/packages/groq-codegen/src/pluck-groq-from-files.test.ts
+++ b/packages/groq-codegen/src/pluck-groq-from-files.test.ts
@@ -22,6 +22,10 @@ describe('pluckGroqFromFile', () => {
           ",
           "queryKey": "BookTitles",
         },
+        Object {
+          "query": "*[_type == 'book']",
+          "queryKey": "AllBooks",
+        },
       ]
     `);
   });


### PR DESCRIPTION
There's a small bug where references don't land in the final codegen file (e.g. `query-types.d.ts`).