### PR TITLE
Named reference types

### DIFF
--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -29,6 +29,7 @@ type ReferenceType = {
   // blog example doesn't follow this.
   to: { type: string } | Array<{ type: string }>;
   weak?: boolean;
+  name?: string;
 };
 type SlugType = { name?: string; type: 'slug' };
 type StringType = {
@@ -295,9 +296,12 @@ async function generateTypes({
         )
         .join(' | ');
 
-      // Note: we want the union to be wrapped by one Reference<T> so when
-      // unwrapped the union can be further discriminated using the `_type`
-      // of each individual reference type
+      const name = (obj as ReferenceType)?.name;
+
+      if (!parents.length && name) {
+        return `{_type: 'name'; _ref: string}`;
+      }
+
       return `SanityReference<${union}>`;
     }
 

--- a/src/generate-types.ts
+++ b/src/generate-types.ts
@@ -298,10 +298,16 @@ async function generateTypes({
 
       const name = (obj as ReferenceType)?.name;
 
+      // In the case that a new, named schema type is defined as a reference.
+      // Sanity treats this like a normal reference, but sets `_type` like
+      // an object. based on `name`.
       if (!parents.length && name) {
         return `{_type: 'name'; _ref: string}`;
       }
 
+      // Note: we want the union to be wrapped by one Reference<T> so when
+      // unwrapped the union can be further discriminated using the `_type`
+      // of each individual reference type
       return `SanityReference<${union}>`;
     }
 


### PR DESCRIPTION
This is a first pass effort at addressing https://github.com/ricokahler/sanity-codegen/issues/191.  This solution involves treating top-level (no parents) references differently.  I have tested this and found its output consistent with the structure sanity returns. 

I have not written tests yet, as I imagine we would want to maybe clean up the formatting of the output.  Also generics are not created for each type in the `to` array like normal references.  I am not sure what the best way to accomplish that is. 


