### PR TITLE
fix: process sometimes not exiting on node 15+

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -114,7 +114,9 @@ async function cli() {
   console.info(`[SanityCodeGen]: types written out to ${outputPath})`);
 }
 
-cli().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+cli()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
Fixes #243 by calling `process.exit(0)` to ensure the process correctly exits after a the successful execution of the `cli` function.

As [mentioned by @ricokahler](https://github.com/ricokahler/sanity-codegen/issues/243#issuecomment-1013937877), Next.js does the same in their codebase.