### PR TITLE
Update README.md

### DIFF
--- a/packages/schema-codegen/README.md
+++ b/packages/schema-codegen/README.md
@@ -51,7 +51,7 @@ The normalized types can then be fed into `generateTypes`. This function takes i
 ```js
 const {
   schemaExtractor,
-  generateTypes,
+  generateSchemaTypes,
 } = require('@sanity-codegen/schema-codegen');
 const fs = require('fs');
 
@@ -59,7 +59,7 @@ async function main() {
   const normalizedSchema = await schemaExtractor({
     schemaPath: './studio/schemas/schema.js',
   });
-  const typescriptSource = await generateTypes({ normalizedSchema });
+  const typescriptSource = await generateSchemaTypes({ normalizedSchema });
 
   await fs.promises.writeFile('./schema.d.ts', typescriptSource);
 }


### PR DESCRIPTION
Update to correct exported function name in the example. Likely the "### `generateTypes()`" section is outdated too.