### PR TITLE
fix(v1): safer handling of child process exits

### DIFF
--- a/packages/extractor/src/schema-executor.ts
+++ b/packages/extractor/src/schema-executor.ts
@@ -126,21 +126,25 @@ async function loadAndExecute() {
   if (!result.length) {
     throw new Error(`Sanity config did not have any workspaces.`);
   }
-
-  const executorResult: ExecutorResult = {
-    status: 'success',
-    result,
-  };
-
-  process.send!(JSON.stringify(executorResult));
+  return result;
 }
 
-loadAndExecute().catch((e) => {
-  const executorResult: ExecutorResult = {
-    status: 'error',
-    error: JSON.stringify({ message: e?.message, stack: e?.stack }, null, 2),
-  };
+loadAndExecute()
+  .then((result) => {
+    const executorResult: ExecutorResult = {
+      status: 'success',
+      result,
+    };
 
-  process.send!(JSON.stringify(executorResult));
-  process.exit(1);
-});
+    process.send!(JSON.stringify(executorResult));
+    process.exitCode = 0;
+  })
+  .catch((e) => {
+    const executorResult: ExecutorResult = {
+      status: 'error',
+      error: JSON.stringify({ message: e?.message, stack: e?.stack }, null, 2),
+    };
+
+    process.send!(JSON.stringify(executorResult));
+    process.exitCode = 1;
+  });

--- a/packages/extractor/src/schema-extractor.ts
+++ b/packages/extractor/src/schema-extractor.ts
@@ -26,13 +26,38 @@ export async function schemaExtractor(params: ExecutorOptions) {
 
   childProcess.send(JSON.stringify(normalizedOptions));
 
-  const message = await new Promise<string>((resolve) => {
-    childProcess.on('message', resolve);
-  });
+  const messageOrResult = await Promise.race([
+    new Promise<string>((resolve) => {
+      // this covers the handled cases by the executor process, either being
+      // successful or an error
+      childProcess.on('message', resolve);
+    }),
+    new Promise<ExecutorResult>((resolve) => {
+      // this covers the unhandled errors by the executor process, such
+      // as top level syntax errors or not found modules
+      childProcess.on('error', (error) => resolve({ status: 'error', error }));
+    }),
+    new Promise<ExecutorResult>((resolve) => {
+      // this is a fallback in case the executor process does not send a
+      // message or error, as should always be the last promise to resolve
+      childProcess.on('close', (exitCode) =>
+        resolve({
+          status: 'error',
+          error:
+            typeof exitCode === 'number'
+              ? `'schema-executor' process exited with status code ${exitCode}`
+              : `'schema-executor' process exited without status code`,
+        }),
+      );
+    }),
+  ]);
 
   childProcess.kill();
 
-  const executorResult: ExecutorResult = JSON.parse(message);
+  const executorResult: ExecutorResult =
+    typeof messageOrResult === 'string'
+      ? JSON.parse(messageOrResult)
+      : messageOrResult;
 
   if (executorResult.status === 'error') {
     // TODO: ensure this serializes correctly and errors bubble up correctly


### PR DESCRIPTION
This MR attempts to improve how child process exits are handled.

Problems I encountered and solved by this fix:
- infinite process indicator when child process exited due to unhandled errors. In my case it happened because of broken installation was thrown because of a missing package
- calling `process.exit(0)` caused that the caller process never receive the message sent with `process!.send(...)`, even when sucessful (not sure why this happens). Just setting `process.exitCode` and letting the process to end normally worked well

Notes:
- I added a `loadAndExecute().then(...)` callback to handle the success case. This way:
  - both success and error cases are handled as close together (parsing and sending messages)
  - the `loadAndExecute` function returns the schema, and the parsing is done in the success handler
- I wrapped the `.on` calls with promises, similar to how it was done previously with the only listener used. Wrapping all of them with `Promise.race` will yield the first one to be resolved, being:
  - `on('message')`: if success or error is handled
  - `on('error')`: if error is not handled in the child process
  - `on('close')`: if process has ended by any other reason. This is just a fallback as it would be expected for the other listeners to be triggered first