### PR TITLE
fix(v1): handle `_key` and `_type` in objects

### DIFF
--- a/packages/core/src/generate-schema-types.ts
+++ b/packages/core/src/generate-schema-types.ts
@@ -22,6 +22,7 @@ export function generateSchemaTypes({
     const structure = transformSchemaNodeToStructure({
       node,
       normalizedSchema,
+      ancestors: [],
     });
 
     // TODO: allow customizing this?


### PR DESCRIPTION
Fixes https://github.com/ricokahler/sanity-codegen/issues/236

The strategy taken has been to recursively forward an `ancestors` array so the parent is available when generating the types for a node. Ff current node is object and parent is array, then it add `_key` and `_type`.

Let me know if those fields should be added in any other cases.

Also @ricokahler I'm not able to run tests, so I have not updated them. But I think it would be good to add a case to ensure this is kept on future refactors/changes.