### PR TITLE
feat(v1): generate identifiers

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,6 +85,14 @@ const config: SanityCodegenConfig = {
    */
   // generateTypeName: undefined,
   /**
+   * Optionally provide a function that generates the typescript workspace
+   * identifier from the schema type name.
+   * 
+   * Please note that this identifier is used for the generated typescript
+   * file, so the returned value should be a valid typescript identifier.
+   */
+  // generateWorkspaceName: undefined,
+  /**
    * This option is fed directly to prettier `resolveConfig`
    *
    * https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options

--- a/packages/core/src/generate-query-types.ts
+++ b/packages/core/src/generate-query-types.ts
@@ -13,16 +13,15 @@ interface GenerateQueryTypesOptions {
    * optionally override the default logger (e.g. to silence it, etc)
    */
   logger?: Sanity.Codegen.Logger;
+  workspaceIdentifier?: string;
 }
 
 export function generateQueryTypes({
   normalizedSchema,
   extractedQueries,
+  workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name),
   ...options
 }: GenerateQueryTypesOptions) {
-  // TODO: allow customizing this?
-  const workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name);
-
   const { logger = simpleLogger } = options;
   const queries = extractedQueries
     .map(({ queryKey, query }) => {

--- a/packages/core/src/generate-schema-types.ts
+++ b/packages/core/src/generate-schema-types.ts
@@ -2,15 +2,18 @@ import * as t from '@babel/types';
 import { defaultGenerateTypeName } from './default-generate-type-name';
 import { transformSchemaNodeToStructure } from './transform-schema-to-structure';
 import { transformStructureToTs } from './transform-structure-to-ts';
+import { GenerateTypesOptions } from './generate-types';
 
 interface GenerateSchemaTypesOptions {
   normalizedSchema: Sanity.SchemaDef.Schema;
   workspaceIdentifier?: string;
+  generateTypeName?: GenerateTypesOptions['generateTypeName'];
 }
 
 export function generateSchemaTypes({
   normalizedSchema,
   workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name),
+  generateTypeName = (typeName) => typeName,
 }: GenerateSchemaTypesOptions) {
   const topLevelSchemaNodes = [
     ...normalizedSchema.documents,
@@ -23,8 +26,11 @@ export function generateSchemaTypes({
       normalizedSchema,
     });
 
-    // TODO: allow customizing this?
-    const identifier = defaultGenerateTypeName(node.name);
+    const identifier = generateTypeName(defaultGenerateTypeName(node.name), {
+      node,
+      nodes: topLevelSchemaNodes,
+      normalizedSchema,
+    });
 
     const { tsType, declarations, substitutions } = transformStructureToTs({
       structure,

--- a/packages/core/src/generate-schema-types.ts
+++ b/packages/core/src/generate-schema-types.ts
@@ -5,14 +5,13 @@ import { transformStructureToTs } from './transform-structure-to-ts';
 
 interface GenerateSchemaTypesOptions {
   normalizedSchema: Sanity.SchemaDef.Schema;
+  workspaceIdentifier?: string;
 }
 
 export function generateSchemaTypes({
   normalizedSchema,
+  workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name),
 }: GenerateSchemaTypesOptions) {
-  // TODO: allow customizing this?
-  const workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name);
-
   const topLevelSchemaNodes = [
     ...normalizedSchema.documents,
     ...normalizedSchema.registeredTypes,

--- a/packages/core/src/generate-types.test.ts
+++ b/packages/core/src/generate-types.test.ts
@@ -127,6 +127,7 @@ describe('generateTypes', () => {
           name: 'additionalWorkspace',
         }),
       ],
+      generateWorkspaceName: (name) => `Overriden${name}`,
       logger: {
         debug: jest.fn(),
         error: jest.fn(),
@@ -141,41 +142,41 @@ describe('generateTypes', () => {
     expect(result).toMatchInlineSnapshot(`
       "/// <reference types="@sanity-codegen/types" />
 
-      namespace Sanity.AdditionalWorkspace.Client {
+      namespace Sanity.OverridenAdditionalWorkspace.Client {
         type Config = {
-          BookAuthorUsesDefaultAlias: Sanity.AdditionalWorkspace.Query.BookAuthorUsesDefaultAlias;
-          BookTitlesUsesDefaultExport: Sanity.AdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
-          AllBooksUsesDefaultReexport: Sanity.AdditionalWorkspace.Query.AllBooksUsesDefaultReexport;
-          AllBooksUsesNamedDeclaredExport: Sanity.AdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
-          AllBooksUsesNameSpecifiedExport: Sanity.AdditionalWorkspace.Query.AllBooksUsesNameSpecifiedExport;
-          ImportStarExportStar: Sanity.AdditionalWorkspace.Query.ImportStarExportStar;
+          BookAuthorUsesDefaultAlias: Sanity.OverridenAdditionalWorkspace.Query.BookAuthorUsesDefaultAlias;
+          BookTitlesUsesDefaultExport: Sanity.OverridenAdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
+          AllBooksUsesDefaultReexport: Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesDefaultReexport;
+          AllBooksUsesNamedDeclaredExport: Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
+          AllBooksUsesNameSpecifiedExport: Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNameSpecifiedExport;
+          ImportStarExportStar: Sanity.OverridenAdditionalWorkspace.Query.ImportStarExportStar;
         };
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type AllBooksUsesDefaultReexport =
-          Sanity.AdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
+          Sanity.OverridenAdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type AllBooksUsesNamedDeclaredExport = {
           authorName: unknown;
           title: unknown;
         }[];
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type AllBooksUsesNameSpecifiedExport =
-          Sanity.AdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type BookAuthorUsesDefaultAlias = unknown;
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type BookTitlesUsesDefaultExport = unknown[];
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type ImportStarExportStar =
-          Sanity.AdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.AdditionalWorkspace.Schema {
+      namespace Sanity.OverridenAdditionalWorkspace.Schema {
         type Foo =
           | {
               _id: string;
@@ -184,33 +185,33 @@ describe('generateTypes', () => {
             }
           | undefined;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesDefaultReexport =
-          Sanity.Default.Query.BookTitlesUsesDefaultExport;
+          Sanity.OverridenDefault.Query.BookTitlesUsesDefaultExport;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesNamedDeclaredExport = {
           authorName: string | null;
           title: string | null;
         }[];
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesNameSpecifiedExport =
-          Sanity.Default.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenDefault.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type BookAuthorUsesDefaultAlias = {
           name?: string;
         } | null;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type BookTitlesUsesDefaultExport = (string | null)[];
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type ImportStarExportStar =
-          Sanity.Default.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenDefault.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.Default.Schema {
+      namespace Sanity.OverridenDefault.Schema {
         type Blocks =
           | {
               _key: string;
@@ -226,7 +227,7 @@ describe('generateTypes', () => {
             }[]
           | undefined;
       }
-      namespace Sanity.Default.Schema {
+      namespace Sanity.OverridenDefault.Schema {
         type Book =
           | {
               _id: string;

--- a/packages/core/src/generate-types.test.ts
+++ b/packages/core/src/generate-types.test.ts
@@ -128,6 +128,7 @@ describe('generateTypes', () => {
         }),
       ],
       generateWorkspaceName: (name) => `Overriden${name}`,
+      generateTypeName: (name) => (name === 'Foo' ? 'Bar' : name),
       logger: {
         debug: jest.fn(),
         error: jest.fn(),
@@ -177,7 +178,7 @@ describe('generateTypes', () => {
           Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
       namespace Sanity.OverridenAdditionalWorkspace.Schema {
-        type Foo =
+        type Bar =
           | {
               _id: string;
               _type: "foo";

--- a/packages/core/src/generate-types.ts
+++ b/packages/core/src/generate-types.ts
@@ -9,6 +9,7 @@ import {
 import { simpleLogger } from './utils';
 import { generateQueryTypes } from './generate-query-types';
 import { generateSchemaTypes } from './generate-schema-types';
+import { defaultGenerateTypeName } from './default-generate-type-name';
 
 const logLevels: Sanity.Codegen.LogLevel[] = [
   'success',
@@ -42,6 +43,21 @@ export interface GenerateTypesOptions extends PluckGroqFromFilesOptions {
    * workspace that mirrors another one in schema (e.g. for staging env)
    */
   ignoreSchemas?: string[];
+
+  root?: string;
+  /**
+   * Function that generates the typescript workspace identifier from the schema
+   * name.
+   *
+   * @param typeName The generated workspace name from the schema name
+   */
+  generateWorkspaceName?: (
+    typeName: string,
+    context: {
+      normalizedSchemas: Sanity.SchemaDef.Schema[];
+      normalizedSchema: Sanity.SchemaDef.Schema;
+    },
+  ) => string;
 }
 
 /**
@@ -56,6 +72,7 @@ export async function generateTypes({
   prettierResolveConfigPath,
   normalizedSchemas,
   ignoreSchemas = [],
+  generateWorkspaceName = (typeName) => typeName,
   ...pluckOptions
 }: GenerateTypesOptions) {
   const { logger = simpleLogger } = pluckOptions;
@@ -83,11 +100,22 @@ export async function generateTypes({
       { ...logger },
     );
 
-    wrappedLogger.verbose(
-      `Generating types for workspace \`${normalizedSchema.name}\``,
+    const workspaceIdentifier = generateWorkspaceName(
+      defaultGenerateTypeName(normalizedSchema.name),
+      {
+        normalizedSchemas: filteredSchemas,
+        normalizedSchema,
+      },
     );
 
-    const schemaTypes = generateSchemaTypes({ normalizedSchema });
+    wrappedLogger.verbose(
+      `Generating types for workspace \`${normalizedSchema.name}\` as \`${workspaceIdentifier}\``,
+    );
+
+    const schemaTypes = generateSchemaTypes({
+      normalizedSchema,
+      workspaceIdentifier,
+    });
     const schemaCount = Object.keys(schemaTypes.declarations).length;
 
     wrappedLogger[schemaCount ? 'success' : 'warn'](
@@ -114,6 +142,7 @@ export async function generateTypes({
       normalizedSchema,
       substitutions: schemaTypes.substitutions,
       extractedQueries,
+      workspaceIdentifier,
     });
     const queryCount = Object.keys(queryTypes.declarations).length;
 

--- a/packages/core/src/generate-types.ts
+++ b/packages/core/src/generate-types.ts
@@ -46,6 +46,19 @@ export interface GenerateTypesOptions extends PluckGroqFromFilesOptions {
 
   root?: string;
   /**
+   * Function that generates the typescript type identifier from the node name.
+   *
+   * @param typeName The generated type name from the node name
+   */
+  generateTypeName?: (
+    typeName: string,
+    context: {
+      normalizedSchema: Sanity.SchemaDef.Schema;
+      node: Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode;
+      nodes: (Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode)[];
+    },
+  ) => string;
+  /**
    * Function that generates the typescript workspace identifier from the schema
    * name.
    *
@@ -72,6 +85,7 @@ export async function generateTypes({
   prettierResolveConfigPath,
   normalizedSchemas,
   ignoreSchemas = [],
+  generateTypeName,
   generateWorkspaceName = (typeName) => typeName,
   ...pluckOptions
 }: GenerateTypesOptions) {
@@ -115,6 +129,7 @@ export async function generateTypes({
     const schemaTypes = generateSchemaTypes({
       normalizedSchema,
       workspaceIdentifier,
+      generateTypeName,
     });
     const schemaCount = Object.keys(schemaTypes.declarations).length;
 


### PR DESCRIPTION
Broken generation of identifiers in 2 function that can be provided in config:
- `generateWorkspaceName`: allows to generate workspace identifiers
- `generateTypeName`: allows to generate type identifiers (for top level schema nodes)

Some notes on the idea behind the implementation:
- I have separated this into 2 function as I see a benefit of having just one for workspaces
- both function have a similar signatures:
  - first parameter is the an already typescript ready identifier, which has been generated from the schema/node name using the default generate type function (so it can be directly returned)
  - second parameter is an object that gives more context of the schema/node. The intent is to:
    - give access to the raw schema/node name (to generate it from it, use it in a `switch`, etc)
    - give access to other schemas/nodes in case custom logic to avoid duplicate names is needed
    - in case of the nodes, give access to the schema being used on in case is needed
  - the returned string should be a valid typescript identifier, and no sanitisation is done

Actual signatures:
```ts
function generateTypeName(
  typeName: string,
  context: {
    normalizedSchema: Sanity.SchemaDef.Schema;
    node: Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode;
    nodes: (Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode)[];
  },
): string;

function generateWorkspaceName(
  typeName: string,
  context: {
    normalizedSchemas: Sanity.SchemaDef.Schema[];
    normalizedSchema: Sanity.SchemaDef.Schema;
  },
): string;
```

Questions:
- should the `defaultGenerateTypeName` helper be renamed to `sanityNameToTypeName` or `sanityNameToIdentifier`?
- should specific usage examples be added in the docs?
