### PR TITLE
feat(v1): custom declarations

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -85,6 +85,14 @@ const config: SanityCodegenConfig = {
    */
   // generateTypeName: undefined,
   /**
+   * Optionally provide a function that generates the typescript workspace
+   * identifier from the schema type name.
+   * 
+   * Please note that this identifier is used for the generated typescript
+   * file, so the returned value should be a valid typescript identifier.
+   */
+  // generateWorkspaceName: undefined,
+  /**
    * This option is fed directly to prettier `resolveConfig`
    *
    * https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options

--- a/packages/cli/src/__example-folders__/cli-tests/inline-schema.config.ts
+++ b/packages/cli/src/__example-folders__/cli-tests/inline-schema.config.ts
@@ -15,10 +15,17 @@ const config: SanityCodegenConfig = {
             { name: 'author', type: 'string' },
           ],
         },
+        {
+          name: 'foo',
+          type: 'document',
+          fields: [{ name: 'myStr', type: 'string' }],
+        },
       ],
     }),
   ],
   include: '**/*.{js,ts,tsx}',
+  generateWorkspaceName: (name) => `Overriden${name}`,
+  generateTypeName: (name) => (name === 'Foo' ? 'Bar' : name),
 };
 
 export default config;

--- a/packages/cli/src/__example-folders__/cli-tests/inline-schema.config.ts
+++ b/packages/cli/src/__example-folders__/cli-tests/inline-schema.config.ts
@@ -26,6 +26,37 @@ const config: SanityCodegenConfig = {
   include: '**/*.{js,ts,tsx}',
   generateWorkspaceName: (name) => `Overriden${name}`,
   generateTypeName: (name) => (name === 'Foo' ? 'Bar' : name),
+  declarations: ({ t, normalizedSchemas, getWorkspaceName }) =>
+    normalizedSchemas.flatMap((normalizedSchema) => [
+      /* ts */ `
+      namespace Sanity.${getWorkspaceName(normalizedSchema)}.Schema {
+        type CustomTypeFromString = {
+          foo: string;
+        };
+      }
+    `,
+      t.tsModuleDeclaration(
+        t.identifier('Sanity'),
+        t.tsModuleDeclaration(
+          t.identifier(getWorkspaceName(normalizedSchema)),
+          t.tsModuleDeclaration(
+            t.identifier('Schema'),
+            t.tsModuleBlock([
+              t.tsTypeAliasDeclaration(
+                t.identifier('CustomTypeFromTSModuleDeclaration'),
+                undefined,
+                t.tsTypeLiteral([
+                  t.tsPropertySignature(
+                    t.identifier('foo'),
+                    t.tsTypeAnnotation(t.tsStringKeyword()),
+                  ),
+                ]),
+              ),
+            ]),
+          ),
+        ),
+      ),
+    ]),
 };
 
 export default config;

--- a/packages/cli/src/commands/codegen.test.ts
+++ b/packages/cli/src/commands/codegen.test.ts
@@ -40,8 +40,8 @@ describe('codegen command', () => {
       [
         "Starting codegen…",
         "Using sanity-codegen config found at <PATH>",
-        "[default] Generating types for workspace \`default\` as \`Default\`",
-        "[default] Converted 1 schema definition to TypeScript",
+        "[default] Generating types for workspace \`default\` as \`OverridenDefault\`",
+        "[default] Converted 2 schema definitions to TypeScript",
         "[default] Plucking queries from files…",
         "[default] Finding files to extract queries from…",
         "[default] Found 2 candidate files",
@@ -63,15 +63,24 @@ describe('codegen command', () => {
       [
         "/// <reference types="@sanity-codegen/types" />
 
-      namespace Sanity.Default.Client {
+      namespace Sanity.OverridenDefault.Client {
         type Config = {
-          QueryKey: Sanity.Default.Query.QueryKey;
+          QueryKey: Sanity.OverridenDefault.Query.QueryKey;
         };
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type QueryKey = (string | null)[];
       }
-      namespace Sanity.Default.Schema {
+      namespace Sanity.OverridenDefault.Schema {
+        type Bar =
+          | {
+              _id: string;
+              _type: "foo";
+              myStr?: string;
+            }
+          | undefined;
+      }
+      namespace Sanity.OverridenDefault.Schema {
         type Book =
           | {
               _id: string;

--- a/packages/cli/src/commands/codegen.test.ts
+++ b/packages/cli/src/commands/codegen.test.ts
@@ -40,7 +40,7 @@ describe('codegen command', () => {
       [
         "Starting codegen…",
         "Using sanity-codegen config found at <PATH>",
-        "[default] Generating types for workspace \`default\`",
+        "[default] Generating types for workspace \`default\` as \`Default\`",
         "[default] Converted 1 schema definition to TypeScript",
         "[default] Plucking queries from files…",
         "[default] Finding files to extract queries from…",

--- a/packages/cli/src/commands/codegen.test.ts
+++ b/packages/cli/src/commands/codegen.test.ts
@@ -72,6 +72,11 @@ describe('codegen command', () => {
         type QueryKey = (string | null)[];
       }
       namespace Sanity.OverridenDefault.Schema {
+        type CustomTypeFromString = {
+          foo: string;
+        };
+      }
+      namespace Sanity.OverridenDefault.Schema {
         type Bar =
           | {
               _id: string;
@@ -89,6 +94,11 @@ describe('codegen command', () => {
               title?: string;
             }
           | undefined;
+      }
+      namespace Sanity.OverridenDefault.Schema {
+        type CustomTypeFromTSModuleDeclaration = {
+          foo: string;
+        };
       }
       ",
       ]

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -155,6 +155,7 @@ export default class GroqCodegen extends Command {
       prettierResolveConfigPath: config?.prettierResolveConfigPath,
       generateTypeName: config?.generateTypeName,
       generateWorkspaceName: config?.generateWorkspaceName,
+      declarations: config?.declarations,
       root,
       normalizedSchemas,
       logger,

--- a/packages/cli/src/commands/codegen.ts
+++ b/packages/cli/src/commands/codegen.ts
@@ -153,6 +153,8 @@ export default class GroqCodegen extends Command {
       babelOptions,
       prettierResolveConfigOptions: config?.prettierResolveConfigOptions,
       prettierResolveConfigPath: config?.prettierResolveConfigPath,
+      generateTypeName: config?.generateTypeName,
+      generateWorkspaceName: config?.generateWorkspaceName,
       root,
       normalizedSchemas,
       logger,

--- a/packages/core/src/__example-files__/example-schema.ts
+++ b/packages/core/src/__example-files__/example-schema.ts
@@ -13,6 +13,14 @@ export const exampleSchema = [
     ],
   },
   {
+    type: 'document',
+    name: 'editorial',
+    fields: [
+      { name: 'title', type: 'string' },
+      { name: 'description', type: 'blocks' },
+    ],
+  },
+  {
     name: 'blocks',
     type: 'array',
     of: [{ type: 'block' }],

--- a/packages/core/src/generate-query-types.ts
+++ b/packages/core/src/generate-query-types.ts
@@ -13,16 +13,15 @@ interface GenerateQueryTypesOptions {
    * optionally override the default logger (e.g. to silence it, etc)
    */
   logger?: Sanity.Codegen.Logger;
+  workspaceIdentifier?: string;
 }
 
 export function generateQueryTypes({
   normalizedSchema,
   extractedQueries,
+  workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name),
   ...options
 }: GenerateQueryTypesOptions) {
-  // TODO: allow customizing this?
-  const workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name);
-
   const { logger = simpleLogger } = options;
   const queries = extractedQueries
     .map(({ queryKey, query }) => {

--- a/packages/core/src/generate-schema-types.ts
+++ b/packages/core/src/generate-schema-types.ts
@@ -2,15 +2,18 @@ import * as t from '@babel/types';
 import { defaultGenerateTypeName } from './default-generate-type-name';
 import { transformSchemaNodeToStructure } from './transform-schema-to-structure';
 import { transformStructureToTs } from './transform-structure-to-ts';
+import { GenerateTypesOptions } from './generate-types';
 
 interface GenerateSchemaTypesOptions {
   normalizedSchema: Sanity.SchemaDef.Schema;
   workspaceIdentifier?: string;
+  generateTypeName?: GenerateTypesOptions['generateTypeName'];
 }
 
 export function generateSchemaTypes({
   normalizedSchema,
   workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name),
+  generateTypeName = (typeName) => typeName,
 }: GenerateSchemaTypesOptions) {
   const topLevelSchemaNodes = [
     ...normalizedSchema.documents,
@@ -23,8 +26,11 @@ export function generateSchemaTypes({
       normalizedSchema,
     });
 
-    // TODO: allow customizing this?
-    const identifier = defaultGenerateTypeName(node.name);
+    const identifier = generateTypeName(defaultGenerateTypeName(node.name), {
+      node,
+      nodes: topLevelSchemaNodes,
+      normalizedSchema,
+    });
 
     const { tsType, declarations, substitutions } = transformStructureToTs({
       structure,

--- a/packages/core/src/generate-schema-types.ts
+++ b/packages/core/src/generate-schema-types.ts
@@ -5,14 +5,13 @@ import { transformStructureToTs } from './transform-structure-to-ts';
 
 interface GenerateSchemaTypesOptions {
   normalizedSchema: Sanity.SchemaDef.Schema;
+  workspaceIdentifier?: string;
 }
 
 export function generateSchemaTypes({
   normalizedSchema,
+  workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name),
 }: GenerateSchemaTypesOptions) {
-  // TODO: allow customizing this?
-  const workspaceIdentifier = defaultGenerateTypeName(normalizedSchema.name);
-
   const topLevelSchemaNodes = [
     ...normalizedSchema.documents,
     ...normalizedSchema.registeredTypes,

--- a/packages/core/src/generate-types.test.ts
+++ b/packages/core/src/generate-types.test.ts
@@ -127,6 +127,7 @@ describe('generateTypes', () => {
           name: 'additionalWorkspace',
         }),
       ],
+      generateWorkspaceName: (name) => `Overriden${name}`,
       logger: {
         debug: jest.fn(),
         error: jest.fn(),
@@ -141,41 +142,41 @@ describe('generateTypes', () => {
     expect(result).toMatchInlineSnapshot(`
       "/// <reference types="@sanity-codegen/types" />
 
-      namespace Sanity.AdditionalWorkspace.Client {
+      namespace Sanity.OverridenAdditionalWorkspace.Client {
         type Config = {
-          BookAuthorUsesDefaultAlias: Sanity.AdditionalWorkspace.Query.BookAuthorUsesDefaultAlias;
-          BookTitlesUsesDefaultExport: Sanity.AdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
-          AllBooksUsesDefaultReexport: Sanity.AdditionalWorkspace.Query.AllBooksUsesDefaultReexport;
-          AllBooksUsesNamedDeclaredExport: Sanity.AdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
-          AllBooksUsesNameSpecifiedExport: Sanity.AdditionalWorkspace.Query.AllBooksUsesNameSpecifiedExport;
-          ImportStarExportStar: Sanity.AdditionalWorkspace.Query.ImportStarExportStar;
+          BookAuthorUsesDefaultAlias: Sanity.OverridenAdditionalWorkspace.Query.BookAuthorUsesDefaultAlias;
+          BookTitlesUsesDefaultExport: Sanity.OverridenAdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
+          AllBooksUsesDefaultReexport: Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesDefaultReexport;
+          AllBooksUsesNamedDeclaredExport: Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
+          AllBooksUsesNameSpecifiedExport: Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNameSpecifiedExport;
+          ImportStarExportStar: Sanity.OverridenAdditionalWorkspace.Query.ImportStarExportStar;
         };
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type AllBooksUsesDefaultReexport =
-          Sanity.AdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
+          Sanity.OverridenAdditionalWorkspace.Query.BookTitlesUsesDefaultExport;
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type AllBooksUsesNamedDeclaredExport = {
           authorName: unknown;
           title: unknown;
         }[];
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type AllBooksUsesNameSpecifiedExport =
-          Sanity.AdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type BookAuthorUsesDefaultAlias = unknown;
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type BookTitlesUsesDefaultExport = unknown[];
       }
-      namespace Sanity.AdditionalWorkspace.Query {
+      namespace Sanity.OverridenAdditionalWorkspace.Query {
         type ImportStarExportStar =
-          Sanity.AdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.AdditionalWorkspace.Schema {
+      namespace Sanity.OverridenAdditionalWorkspace.Schema {
         type Foo =
           | {
               _id: string;
@@ -184,33 +185,33 @@ describe('generateTypes', () => {
             }
           | undefined;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesDefaultReexport =
-          Sanity.Default.Query.BookTitlesUsesDefaultExport;
+          Sanity.OverridenDefault.Query.BookTitlesUsesDefaultExport;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesNamedDeclaredExport = {
           authorName: string | null;
           title: string | null;
         }[];
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesNameSpecifiedExport =
-          Sanity.Default.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenDefault.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type BookAuthorUsesDefaultAlias = {
           name?: string;
         } | null;
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type BookTitlesUsesDefaultExport = (string | null)[];
       }
-      namespace Sanity.Default.Query {
+      namespace Sanity.OverridenDefault.Query {
         type ImportStarExportStar =
-          Sanity.Default.Query.AllBooksUsesNamedDeclaredExport;
+          Sanity.OverridenDefault.Query.AllBooksUsesNamedDeclaredExport;
       }
-      namespace Sanity.Default.Schema {
+      namespace Sanity.OverridenDefault.Schema {
         type Blocks =
           | {
               _key: string;
@@ -226,7 +227,7 @@ describe('generateTypes', () => {
             }[]
           | undefined;
       }
-      namespace Sanity.Default.Schema {
+      namespace Sanity.OverridenDefault.Schema {
         type Book =
           | {
               _id: string;

--- a/packages/core/src/generate-types.test.ts
+++ b/packages/core/src/generate-types.test.ts
@@ -1,8 +1,44 @@
 import { schemaNormalizer } from './schema-normalizer';
-import { generateTypes } from './generate-types';
+import { GenerateTypesOptions, generateTypes } from './generate-types';
 import { exampleSchema } from './__example-files__/example-schema';
 
 describe('generateTypes', () => {
+  const declarations: GenerateTypesOptions['declarations'] = ({
+    t,
+    normalizedSchemas,
+    getWorkspaceName,
+  }) =>
+    normalizedSchemas.flatMap((normalizedSchema) => [
+      /* ts */ `
+      namespace Sanity.${getWorkspaceName(normalizedSchema)}.Schema {
+        type CustomTypeFromString = {
+          foo: string;
+        };
+      }
+    `,
+      t.tsModuleDeclaration(
+        t.identifier('Sanity'),
+        t.tsModuleDeclaration(
+          t.identifier(getWorkspaceName(normalizedSchema)),
+          t.tsModuleDeclaration(
+            t.identifier('Schema'),
+            t.tsModuleBlock([
+              t.tsTypeAliasDeclaration(
+                t.identifier('CustomTypeFromTSModuleDeclaration'),
+                undefined,
+                t.tsTypeLiteral([
+                  t.tsPropertySignature(
+                    t.identifier('foo'),
+                    t.tsTypeAnnotation(t.tsStringKeyword()),
+                  ),
+                ]),
+              ),
+            ]),
+          ),
+        ),
+      ),
+    ]);
+
   // TODO: better tests lol
   it('works', async () => {
     const result = await generateTypes({
@@ -21,6 +57,7 @@ describe('generateTypes', () => {
         verbose: jest.fn(),
         warn: jest.fn(),
       },
+      declarations,
     });
 
     expect(result).toMatchInlineSnapshot(`
@@ -63,6 +100,11 @@ describe('generateTypes', () => {
           Sanity.Default.Query.AllBooksUsesNamedDeclaredExport;
       }
       namespace Sanity.Default.Schema {
+        type CustomTypeFromString = {
+          foo: string;
+        };
+      }
+      namespace Sanity.Default.Schema {
         type Blocks =
           | {
               _key: string;
@@ -90,6 +132,11 @@ describe('generateTypes', () => {
               title?: string;
             }
           | undefined;
+      }
+      namespace Sanity.Default.Schema {
+        type CustomTypeFromTSModuleDeclaration = {
+          foo: string;
+        };
       }
       namespace Sanity.Ref {
         type Ref_0NJ3QI56wvVs4iZM = {
@@ -129,6 +176,7 @@ describe('generateTypes', () => {
       ],
       generateWorkspaceName: (name) => `Overriden${name}`,
       generateTypeName: (name) => (name === 'Foo' ? 'Bar' : name),
+      declarations,
       logger: {
         debug: jest.fn(),
         error: jest.fn(),
@@ -178,6 +226,11 @@ describe('generateTypes', () => {
           Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
       namespace Sanity.OverridenAdditionalWorkspace.Schema {
+        type CustomTypeFromString = {
+          foo: string;
+        };
+      }
+      namespace Sanity.OverridenAdditionalWorkspace.Schema {
         type Bar =
           | {
               _id: string;
@@ -185,6 +238,11 @@ describe('generateTypes', () => {
               myStr?: string;
             }
           | undefined;
+      }
+      namespace Sanity.OverridenAdditionalWorkspace.Schema {
+        type CustomTypeFromTSModuleDeclaration = {
+          foo: string;
+        };
       }
       namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesDefaultReexport =
@@ -211,6 +269,11 @@ describe('generateTypes', () => {
       namespace Sanity.OverridenDefault.Query {
         type ImportStarExportStar =
           Sanity.OverridenDefault.Query.AllBooksUsesNamedDeclaredExport;
+      }
+      namespace Sanity.OverridenDefault.Schema {
+        type CustomTypeFromString = {
+          foo: string;
+        };
       }
       namespace Sanity.OverridenDefault.Schema {
         type Blocks =
@@ -240,6 +303,11 @@ describe('generateTypes', () => {
               title?: string;
             }
           | undefined;
+      }
+      namespace Sanity.OverridenDefault.Schema {
+        type CustomTypeFromTSModuleDeclaration = {
+          foo: string;
+        };
       }
       namespace Sanity.Ref {
         type Ref_0NJ3QI56wvVs4iZM = {

--- a/packages/core/src/generate-types.test.ts
+++ b/packages/core/src/generate-types.test.ts
@@ -128,6 +128,7 @@ describe('generateTypes', () => {
         }),
       ],
       generateWorkspaceName: (name) => `Overriden${name}`,
+      generateTypeName: (name) => (name === 'Foo' ? 'Bar' : name),
       logger: {
         debug: jest.fn(),
         error: jest.fn(),
@@ -177,7 +178,7 @@ describe('generateTypes', () => {
           Sanity.OverridenAdditionalWorkspace.Query.AllBooksUsesNamedDeclaredExport;
       }
       namespace Sanity.OverridenAdditionalWorkspace.Schema {
-        type Foo =
+        type Bar =
           | {
               _id: string;
               _type: "foo";

--- a/packages/core/src/generate-types.test.ts
+++ b/packages/core/src/generate-types.test.ts
@@ -7,15 +7,16 @@ describe('generateTypes', () => {
     t,
     normalizedSchemas,
     getWorkspaceName,
+    getTypeName,
   }) =>
     normalizedSchemas.flatMap((normalizedSchema) => [
       /* ts */ `
-      namespace Sanity.${getWorkspaceName(normalizedSchema)}.Schema {
-        type CustomTypeFromString = {
-          foo: string;
-        };
-      }
-    `,
+        namespace Sanity.${getWorkspaceName(normalizedSchema)}.Schema {
+          type CustomTypeFromString = {
+            foo: string;
+          };
+        }
+      `,
       t.tsModuleDeclaration(
         t.identifier('Sanity'),
         t.tsModuleDeclaration(
@@ -32,6 +33,15 @@ describe('generateTypes', () => {
                     t.tsTypeAnnotation(t.tsStringKeyword()),
                   ),
                 ]),
+              ),
+              t.tsTypeAliasDeclaration(
+                t.identifier('Documents'),
+                undefined,
+                t.tsUnionType(
+                  normalizedSchema.documents.map((node) =>
+                    t.tsTypeReference(t.identifier(getTypeName(node))),
+                  ),
+                ),
               ),
             ]),
           ),
@@ -128,7 +138,7 @@ describe('generateTypes', () => {
               author?: {
                 name?: string;
               };
-              description?: Sanity.Ref.Ref_0NJ3QI56wvVs4iZM;
+              description?: Sanity.Ref.Ref_CSyMjBFeCfC4y2Vp;
               title?: string;
             }
           | undefined;
@@ -137,9 +147,20 @@ describe('generateTypes', () => {
         type CustomTypeFromTSModuleDeclaration = {
           foo: string;
         };
+        type Documents = Book | Editorial;
+      }
+      namespace Sanity.Default.Schema {
+        type Editorial =
+          | {
+              _id: string;
+              _type: "editorial";
+              description?: Sanity.Ref.Ref_CSyMjBFeCfC4y2Vp;
+              title?: string;
+            }
+          | undefined;
       }
       namespace Sanity.Ref {
-        type Ref_0NJ3QI56wvVs4iZM = {
+        type Ref_CSyMjBFeCfC4y2Vp = {
           _key: string;
           _type: "block";
           children: {
@@ -243,6 +264,7 @@ describe('generateTypes', () => {
         type CustomTypeFromTSModuleDeclaration = {
           foo: string;
         };
+        type Documents = Bar;
       }
       namespace Sanity.OverridenDefault.Query {
         type AllBooksUsesDefaultReexport =
@@ -299,7 +321,7 @@ describe('generateTypes', () => {
               author?: {
                 name?: string;
               };
-              description?: Sanity.Ref.Ref_0NJ3QI56wvVs4iZM;
+              description?: Sanity.Ref.Ref_CSyMjBFeCfC4y2Vp;
               title?: string;
             }
           | undefined;
@@ -308,9 +330,20 @@ describe('generateTypes', () => {
         type CustomTypeFromTSModuleDeclaration = {
           foo: string;
         };
+        type Documents = Book | Editorial;
+      }
+      namespace Sanity.OverridenDefault.Schema {
+        type Editorial =
+          | {
+              _id: string;
+              _type: "editorial";
+              description?: Sanity.Ref.Ref_CSyMjBFeCfC4y2Vp;
+              title?: string;
+            }
+          | undefined;
       }
       namespace Sanity.Ref {
-        type Ref_0NJ3QI56wvVs4iZM = {
+        type Ref_CSyMjBFeCfC4y2Vp = {
           _key: string;
           _type: "block";
           children: {

--- a/packages/core/src/generate-types.ts
+++ b/packages/core/src/generate-types.ts
@@ -9,6 +9,7 @@ import {
 import { simpleLogger } from './utils';
 import { generateQueryTypes } from './generate-query-types';
 import { generateSchemaTypes } from './generate-schema-types';
+import { defaultGenerateTypeName } from './default-generate-type-name';
 
 const logLevels: Sanity.Codegen.LogLevel[] = [
   'success',
@@ -42,6 +43,21 @@ export interface GenerateTypesOptions extends PluckGroqFromFilesOptions {
    * workspace that mirrors another one in schema (e.g. for staging env)
    */
   ignoreSchemas?: string[];
+
+  root?: string;
+  /**
+   * Function that generates the typescript workspace identifier from the schema
+   * name.
+   *
+   * @param typeName The generated workspace name from the schema name
+   */
+  generateWorkspaceName?: (
+    typeName: string,
+    context: {
+      normalizedSchemas: Sanity.SchemaDef.Schema[];
+      normalizedSchema: Sanity.SchemaDef.Schema;
+    },
+  ) => string;
 }
 
 /**
@@ -56,6 +72,7 @@ export async function generateTypes({
   prettierResolveConfigPath,
   normalizedSchemas,
   ignoreSchemas = [],
+  generateWorkspaceName = (typeName) => typeName,
   ...pluckOptions
 }: GenerateTypesOptions) {
   const { logger = simpleLogger } = pluckOptions;
@@ -83,11 +100,22 @@ export async function generateTypes({
       { ...logger },
     );
 
-    wrappedLogger.verbose(
-      `Generating types for workspace \`${normalizedSchema.name}\``,
+    const workspaceIdentifier = generateWorkspaceName(
+      defaultGenerateTypeName(normalizedSchema.name),
+      {
+        normalizedSchemas: filteredSchemas,
+        normalizedSchema,
+      },
     );
 
-    const schemaTypes = generateSchemaTypes({ normalizedSchema });
+    wrappedLogger.verbose(
+      `Generating types for workspace \`${normalizedSchema.name}\` as \`${workspaceIdentifier}\``,
+    );
+
+    const schemaTypes = generateSchemaTypes({
+      normalizedSchema,
+      workspaceIdentifier,
+    });
     const schemaCount = Object.keys(schemaTypes.declarations).length;
 
     wrappedLogger[schemaCount ? 'success' : 'warn'](
@@ -114,6 +142,7 @@ export async function generateTypes({
       normalizedSchema,
       substitutions: schemaTypes.substitutions,
       extractedQueries,
+      workspaceIdentifier,
     });
     const queryCount = Object.keys(queryTypes.declarations).length;
 

--- a/packages/core/src/generate-types.ts
+++ b/packages/core/src/generate-types.ts
@@ -46,6 +46,19 @@ export interface GenerateTypesOptions extends PluckGroqFromFilesOptions {
 
   root?: string;
   /**
+   * Function that generates the typescript type identifier from the node name.
+   *
+   * @param typeName The generated type name from the node name
+   */
+  generateTypeName?: (
+    typeName: string,
+    context: {
+      normalizedSchema: Sanity.SchemaDef.Schema;
+      node: Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode;
+      nodes: (Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode)[];
+    },
+  ) => string;
+  /**
    * Function that generates the typescript workspace identifier from the schema
    * name.
    *
@@ -72,6 +85,7 @@ export async function generateTypes({
   prettierResolveConfigPath,
   normalizedSchemas,
   ignoreSchemas = [],
+  generateTypeName,
   generateWorkspaceName = (typeName) => typeName,
   ...pluckOptions
 }: GenerateTypesOptions) {
@@ -115,6 +129,7 @@ export async function generateTypes({
     const schemaTypes = generateSchemaTypes({
       normalizedSchema,
       workspaceIdentifier,
+      generateTypeName,
     });
     const schemaCount = Object.keys(schemaTypes.declarations).length;
 

--- a/packages/core/src/generate-types.ts
+++ b/packages/core/src/generate-types.ts
@@ -54,8 +54,13 @@ export interface GenerateTypesOptions extends PluckGroqFromFilesOptions {
     typeName: string,
     context: {
       normalizedSchema: Sanity.SchemaDef.Schema;
-      node: Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode;
-      nodes: (Sanity.SchemaDef.DocumentNode | Sanity.SchemaDef.RegisteredSchemaNode)[];
+      node:
+        | Sanity.SchemaDef.DocumentNode
+        | Sanity.SchemaDef.RegisteredSchemaNode;
+      nodes: (
+        | Sanity.SchemaDef.DocumentNode
+        | Sanity.SchemaDef.RegisteredSchemaNode
+      )[];
     },
   ) => string;
   /**


### PR DESCRIPTION
I've started this branch from https://github.com/ricokahler/sanity-codegen/pull/299, so that should be merged first.

----------

The intent of this PR is to allow to configure declarations in the configuration file so they are included in the generated types. This only covers the possibility of ADDING declarations, not alter the generated ones.

Possible use cases:
- add types that are not inferred from the schema itself
- add types derived from the generated types

The `declarations` configuration can be:
```ts
/**
 * Custom declarations to be added to the generated types
 */
declarations?:
  | (string | t.TSModuleDeclaration)[]
  | ((context: {
      t: typeof t;
      normalizedSchemas: Sanity.SchemaDef.Schema[];
      generateTypeName: GenerateTypesOptions['generateTypeName'];
      generateWorkspaceName: GenerateTypesOptions['generateWorkspaceName'];
      defaultGenerateTypeName: typeof defaultGenerateTypeName;
      getWorkspaceName: (normalizedSchema: Sanity.SchemaDef.Schema) => string;
    }) =>
      | (string | t.TSModuleDeclaration)[]
      | Promise<(string | t.TSModuleDeclaration)[]>);
```

The above allows to directly pass declarations (as strings or with babel's `t` helpers for typesafety), or a function that returns the very same. This can be used to add more complex logic to generate types derived from the schemas (see exmaples below).

--------

#### Example 1:

Add a static type (this would help us solve the https://github.com/ricokahler/sanity-codegen/issues/298 issue):

```ts
const config: SanityCodegenConfig = {
  // ... other
  declarations: [
    /* ts */ `
      namespace Sanity {
        type Reference<T> =
          | T
          | {
            _type: "reference";
            _ref: string;
        };
      }
    `,
  ],
};
```

--------

#### Example 2:

Generate a new `Documents` type for each schema, which is a union of all types in that schema:

```ts
const config: SanityCodegenConfig = {
  // ... other
  declarations: ({
    t,
    normalizedSchemas,
    getWorkspaceName,
    getTypeName,
  }) =>
    normalizedSchemas.flatMap((normalizedSchema) => [
      t.tsModuleDeclaration(
        t.identifier('Sanity'),
        t.tsModuleDeclaration(
          t.identifier(getWorkspaceName(normalizedSchema)),
          t.tsModuleDeclaration(
            t.identifier('Schema'),
            t.tsModuleBlock([
              t.tsTypeAliasDeclaration(
                t.identifier('Documents'),
                undefined,
                t.tsUnionType(
                  normalizedSchema.documents.map((node) =>
                    t.tsTypeReference(t.identifier(getTypeName(node))),
                  ),
                ),
              ),
            ]),
          ),
        ),
      ),
    ]),
};
```
That yields something like:

```ts
namespace Sanity.Default.Schema {
  type Documents = Book | Editorial;
}
```
------

@ricokahler please let me know your thoughts on this, I'm finding it pretty useful!



